### PR TITLE
Fixed averages not showing in the newest version.

### DIFF
--- a/static/bakalariprumer.js
+++ b/static/bakalariprumer.js
@@ -76,7 +76,7 @@ function addMarkAdders () {
 }
 jQuery(document).ready(function() {
 	if(window.location.href.indexOf("prubzna.aspx") > -1) {
-		calculateWeightedAvg();
+		setTimeout(calculateWeightedAvg,1);
 		addMarkAdders();
 	}
 });


### PR DESCRIPTION
Something is overwriting our averages in the newest version, this fixes it by adding the averages in a millisecond later.