### PR TITLE
Changed `querySelector("#" +...` to `getElementById(...`

### DIFF
--- a/static/bakalariprumer.js
+++ b/static/bakalariprumer.js
@@ -25,7 +25,7 @@ document.addEventListener("DOMContentLoaded", () => {
     document.querySelectorAll(".pridavac-znamek button").forEach(e => {
         e.addEventListener("click", (event) => {
             event.preventDefault();
-            const radek = document.querySelector("#" + e.dataset.id);
+            const radek = document.getElementById(e.dataset.id);
             const znamky = radek.querySelector(".znamky");
             const znamkaDiv = document.createElement("div");
             const znamka = radek.querySelector(".znamka-input").value;


### PR DESCRIPTION
I'm sorry to bother you again, but ids starting with a number should be valid in HTML5, but `querySelector` doesn't accept them while `getElementById` does. Bakaláři use their internal IDs as element ids, and some begin with a number. So it used to brake for some subjects. It shouldn't now. 